### PR TITLE
Syntax highlight

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint",
-        "github.vscode-github-actions"
+        "github.vscode-github-actions",
+        "redcmd.tmlanguage-syntax-highlighter"
     ]
 }

--- a/BUILD.md
+++ b/BUILD.md
@@ -43,8 +43,15 @@ This repository contains 2 versions of the language server: the desktop version 
 
 ## Debug
 
+### TypeScript code
+
 -   If you want to write something to the console, use `this.connection.console.log` (actually, if you run the server from Visual Studio Code, `console.log` will work, however, in Visual Studio, only `this.connection.console.log` will work, `console.log` will break the extension).
 -   If you want to use breakpoints, you have to configure the client properly. For more informations see the [Visual Studio Code client's build instructions](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Support-for-Visual-Studio-Code/blob/main/BUILD.md).
+
+### TextMate grammar
+
+-   If you want to know which TextMate rule matched at the cursor, press F1, and select **Developer: Inspect Editor Tokens and Scopes**.
+-   If you want to read the steps of the TextMate matching, press F1, and select **Developer: Start Text Mate Syntax Grammar Logging**.
 
 ## Scripts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,3 @@ There are no public releases yet.
 ## [Unreleased]
 
 -   Syntax highlight (not part of the actual language server)
--   Diagnostics (mocked)
--   Code completion (mocked)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@ There are no public releases yet.
 
 ## [Unreleased]
 
+-   Syntax highlight (not part of the actual language server)
 -   Diagnostics (mocked)
 -   Code completion (mocked)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Gaijin Games Kft.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 [![build](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/actions/workflows/build.yml/badge.svg)](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/actions/workflows/build.yml)
 
-Language Server for the Dagor Shader Language. At the moment it's work in progress and most of it's features are mocked. There is a [Visual Studio Code client](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Support-for-Visual-Studio-Code).
+Language Server for the Dagor Shader Language. At the moment it's work in progress. There is a [Visual Studio Code client](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Support-for-Visual-Studio-Code).
 
 ## Features
 
 -   Syntax highlight (not part of the actual language server)
--   Diagnostics (mocked)
--   Code completion (mocked)
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Language Server for the Dagor Shader Language. At the moment it's work in progre
 
 ## Features
 
+-   Syntax highlight (not part of the actual language server)
 -   Diagnostics (mocked)
 -   Code completion (mocked)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/actions/workflows/build.yml/badge.svg)](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/actions/workflows/build.yml)
 
-Language Server for the Dagor Shader Language. At the moment it's work in progress and all features are mocked. There is a [Visual Studio Code client](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Support-for-Visual-Studio-Code).
+Language Server for the Dagor Shader Language. At the moment it's work in progress and most of it's features are mocked. There is a [Visual Studio Code client](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Support-for-Visual-Studio-Code).
 
 ## Features
 

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -1,0 +1,608 @@
+{
+    "scopeName": "source.dagorsh",
+    "name": "DagorShader",
+    "fileTypes": ["sh"],
+    "patterns": [
+        {
+            "include": "#macro_block"
+        },
+        {
+            "include": "#strings"
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#hlsl_block"
+        },
+        {
+            "include": "#block_block"
+        },
+        {
+            "include": "#shader_variables"
+        },
+        {
+            "include": "#shader_block"
+        },
+        {
+            "include": "#shader_ops"
+        }
+    ],
+    "repository": {
+        "macro_block": {
+            "patterns": [
+                {
+                    "begin": "\\b(macro|define_macro_if_not_defined)\\s*(\\w+)\\b",
+                    "end": "\\b(endmacro)\\b",
+                    "captures": {
+                        "1": { "name": "keyword.other.source.dagorsh" },
+                        "2": { "name": "name.macro.source.dagor" }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "include": "#binding_types"
+                        },
+                        {
+                            "include": "#hlsl_block"
+                        },
+                        {
+                            "include": "#declaration_block"
+                        },
+                        {
+                            "include": "#shader_variables"
+                        },
+                        {
+                            "include": "#shader_ops"
+                        },
+                        {
+                            "include": "#material_block"
+                        }
+                    ]
+                }
+            ]
+        },
+        "material_ops": {
+            "patterns": [
+                {
+                    "match": "(\\w+)(\\s*)(=)(\\s*)(mat.)(ambient|diffuse|emissive|specular)(\\s*)(;)",
+                    "captures": {
+                        "1": { "name": "variable.source.dagorsh" },
+                        "5": { "name": "support.constant.source.dagorsh" },
+                        "6": { "name": "support.constant.source.dagorsh" }
+                    }
+                },
+                {
+                    "match": "(\\w+)(\\s*)(=)(\\s*)(mat.texture.)(\\s*)(\\w+)(;)",
+                    "captures": {
+                        "1": { "name": "variable.source.dagorsh" },
+                        "5": { "name": "support.constant.source.dagorsh" },
+                        "7": { "name": "support.constant.source.dagorsh" }
+                    }
+                }
+            ]
+        },
+        "material_block": {
+            "patterns": [
+                {
+                    "begin": "\\b(init)\\b",
+                    "end": "(?<=})",
+                    "beginCaptures": {
+                        "1": { "name": "support.class.source.dagor" }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "({)",
+                            "end": "(})",
+                            "patterns": [
+                                {
+                                    "include": "#comments"
+                                },
+                                {
+                                    "include": "#strings"
+                                },
+                                {
+                                    "include": "#material_ops"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "numbers": {
+            "patterns": [
+                {
+                    "match": "\\b([0-9]+\\.?[0-9]*(f?F?h?H?l?L?|e-?[0-9]+))\\b",
+                    "name": "constant.numeric.source.dagorsh"
+                }
+            ]
+        },
+        "shader_ops": {
+            "patterns": [
+                {
+                    "match": "\\b(blend_asrc|blend_adst|blend_src|blend_dst|cull_mode|alpha_to_coverage|view_instances|z_write|z_test|z_func|stencil|stencil_func|stencil_ref|stencil_pass|stencil_fail|stencil_zfail|color_write|slope_z_bias|z_bias)\\b",
+                    "name": "support.variable.source.dagorsh"
+                },
+                {
+                    "match": "\\b(color8|float1|float2|float3|float4|short2|short4|ubyte4|short2n|short4n|ushort2n|ushort4n|half2|half4|udec3|dec3n|extra|norm|pos|tc|vcol|signed_pack|unsigned_pack|mul_1k|mul_2k|mul_4k|mul_8k|mul_16k|mul_32767|bounding_pack)\\b",
+                    "name": "support.variable.source.dagorsh"
+                },
+                {
+                    "match": "\\b(two_sided|real_two_sided|true|false|globtm|projtm|viewprojtm|local_view_x|local_view_y|local_view_z|local_view_pos|world_local_x|world_local_y|world_local_z|world_local_pos|vpr_const_array)\\b",
+                    "name": "support.constant.source.dagorsh"
+                },
+                {
+                    "match": "\\b(zero|one|sc|isc|sa|isa|da|ida|dc|idc|sasat|bf|ibf)\\b",
+                    "name": "support.constant.source.dagorsh"
+                },
+                {
+                    "match": "\\b(keep|zero|replace|incrsat|decrsat|incr|dect)\\b",
+                    "name": "support.constant.source.dagorsh"
+                },
+                {
+                    "match": "\\b(never|less|equal|lessequal|greater|notequal|greaterequal|always)\\b",
+                    "name": "support.constant.source.dagorsh"
+                },
+                {
+                    "match": "\\b(cw|ccw|none)\\b",
+                    "name": "support.constant.source.dagorsh"
+                },
+                {
+                    "match": "\\b(include|include_optional|compile|channel|render_stage|supports|use)\\b",
+                    "name": "keyword.other.source.dagorsh"
+                },
+                {
+                    "match": "\\b(interval|dont_render|no_dynstcode|render_trans|no_ablend|assume)\\b",
+                    "name": "keyword.control.source.dagorsh"
+                },
+                {
+                    "match": "\\b(if|else)\\b",
+                    "name": "keyword.control.source.dagorsh"
+                },
+                {
+                    "match": "(NULL)",
+                    "name": "constant.language.source.dagorsh"
+                },
+                {
+                    "include": "#declaration_block"
+                },
+                {
+                    "include": "#numbers"
+                },
+                {
+                    "include": "#strings"
+                },
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#hlsl_block"
+                },
+                {
+                    "begin": "{",
+                    "end": "}",
+                    "patterns": [
+                        {
+                            "include": "#shader_ops"
+                        }
+                    ]
+                }
+            ]
+        },
+        "shader_variables": {
+            "patterns": [
+                {
+                    "match": "\\b(int|int4|float|float4|float4x4|texture|buffer|const_buffer|define|undef)\\b",
+                    "name": "support.type.source.dagorsh"
+                },
+                {
+                    "match": "\\b(local|dynamic|static|const|always_referenced|undefined_value|no_warnings|public)\\b",
+                    "name": "storage.modifier.source.dagorsh"
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "begin": "//",
+                    "end": "$",
+                    "name": "comment.line.double-slash.source.dagorsh"
+                },
+                {
+                    "begin": "/\\*",
+                    "end": "\\*/",
+                    "name": "comment.line.block.source.dagorsh"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "begin": "\"",
+                    "end": "\"",
+                    "name": "string.quoted.double.source.dagorsh"
+                }
+            ]
+        },
+        "binding_types": {
+            "patterns": [
+                {
+                    "match": "(@)(static|vsf|vsmp|psf|shd|smp(2d|3d|Array|Cube)?|tex(2d|3d|Array|Cube)?|csf|ps_buf|vs_buf|cs_buf|ps_cbuf|vs_cbuf|cs_cbuf|buf|f(1|2|3|4+)|i(1|2|3|4))",
+                    "name": "support.type.source.dagorsh"
+                }
+            ]
+        },
+        "declaration_block": {
+            "patterns": [
+                {
+                    "include": "#declaration_block_a"
+                },
+                {
+                    "include": "#declaration_block_b"
+                }
+            ]
+        },
+        "declaration_block_a": {
+            "patterns": [
+                {
+                    "begin": "^\\s*(\\(\\w+\\))\\s*{",
+                    "end": "(?<=})",
+                    "beginCaptures": {
+                        "1": { "name": "support.class.hlsl.source.dagor" }
+                    },
+                    "patterns": [
+                        {
+                            "match": "\\b(if|else)\\b",
+                            "name": "keyword.control.source.dagorsh"
+                        },
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "include": "#numbers"
+                        },
+                        {
+                            "include": "#binding_types"
+                        },
+                        {
+                            "include": "#hlsl_block"
+                        },
+                        {
+                            "include": "#declaration_block_body"
+                        }
+                    ]
+                }
+            ]
+        },
+        "declaration_block_b": {
+            "patterns": [
+                {
+                    "begin": "^\\s*(\\(\\w+\\))\\s*$",
+                    "end": "(?<=})",
+                    "beginCaptures": {
+                        "1": { "name": "support.class.hlsl.source.dagor" }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#declaration_block_body"
+                        }
+                    ]
+                }
+            ]
+        },
+        "declaration_block_body": {
+            "patterns": [
+                {
+                    "begin": "({)",
+                    "end": "(})",
+                    "patterns": [
+                        {
+                            "match": "\\b(if|else)\\b",
+                            "name": "keyword.control.source.dagorsh"
+                        },
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "include": "#numbers"
+                        },
+                        {
+                            "include": "#binding_types"
+                        },
+                        {
+                            "include": "#hlsl_block"
+                        },
+                        {
+                            "include": "#declaration_block_body"
+                        }
+                    ]
+                }
+            ]
+        },
+        "shader_block": {
+            "patterns": [
+                {
+                    "begin": "\\b(shader)\\s*(\\w+)((,\\s*\\w+)*)\\b",
+                    "end": "(?<=})",
+                    "beginCaptures": {
+                        "1": { "name": "support.class.source.dagor" },
+                        "2": { "name": "name.source.dagorsh" },
+                        "3": { "name": "name.source.dagorsh" }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "({)",
+                            "end": "(})",
+                            "patterns": [
+                                {
+                                    "include": "#comments"
+                                },
+                                {
+                                    "include": "#strings"
+                                },
+                                {
+                                    "include": "#shader_ops"
+                                },
+                                {
+                                    "include": "#declaration_block"
+                                },
+                                {
+                                    "include": "#hlsl_block"
+                                },
+                                {
+                                    "include": "#shader_variables"
+                                },
+                                {
+                                    "include": "#material_block"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "block_block": {
+            "patterns": [
+                {
+                    "begin": "(block)(\\(\\w+\\))(\\s*)(\\w+)",
+                    "end": "(?<=})",
+                    "beginCaptures": {
+                        "1": { "name": "support.class.source.dagor" },
+                        "2": { "name": "support.class.source.dagor" },
+                        "4": { "name": "name.block.source.dagor" }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "({)",
+                            "end": "(})",
+                            "patterns": [
+                                {
+                                    "include": "#comments"
+                                },
+                                {
+                                    "include": "#strings"
+                                },
+                                {
+                                    "include": "#shader_ops"
+                                },
+                                {
+                                    "include": "#declaration_block"
+                                },
+                                {
+                                    "include": "#hlsl_block"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "hlsl_block": {
+            "patterns": [
+                {
+                    "begin": "(\\(\\w+\\)|)\\s*(hlsl)\\s*(\\(\\w+\\)|)",
+                    "end": "(?<=})",
+                    "beginCaptures": {
+                        "1": { "name": "support.class.hlsl.source.dagor" },
+                        "2": { "name": "support.class.hlsl.source.dagor" },
+                        "3": { "name": "support.class.hlsl.source.dagor" }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "({)",
+                            "end": "(})",
+                            "patterns": [
+                                {
+                                    "include": "#hlsl"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "hlsl": {
+            "patterns": [
+                {
+                    "match": "\\b(bool|bool1|bool2|bool3|bool4)\\b",
+                    "name": "storage.type.hlsl.source.dagorshj"
+                },
+                {
+                    "match": "\\b(int|int1|int2|int3|int4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(uint|uint1|uint2|uint3|uint4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(dword|dword1|dword2|dword3|dword4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(half|half1|half2|half3|half4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(float|float1|float2|float3|float4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(double|double1|double2|double3|double4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(uint64_t|uint64_t1|uint64_t2|uint64_t3|uint64_t4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(matrix)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(bool1x1|bool1x2|bool1x3|bool1x4|bool2x1|bool2x2|bool2x3|bool2x4|bool3x1|bool3x2|bool3x3|bool3x4|bool4x1|bool4x2|bool4x3|bool4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(int1x1|int1x2|int1x3|int1x4|int2x1|int2x2|int2x3|int2x4|int3x1|int3x2|int3x3|int3x4|int4x1|int4x2|int4x3|int4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(uint1x1|uint1x2|uint1x3|uint1x4|uint2x1|uint2x2|uint2x3|uint2x4|uint3x1|uint3x2|uint3x3|uint3x4|uint4x1|uint4x2|uint4x3|uint4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(dword1x1|dword1x2|dword1x3|dword1x4|dword2x1|dword2x2|dword2x3|dword2x4|dword3x1|dword3x2|dword3x3|dword3x4|dword4x1|dword4x2|dword4x3|dword4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(half1x1|half1x2|half1x3|half1x4|half2x1|half2x2|half2x3|half2x4|half3x1|half3x2|half3x3|half3x4|half4x1|half4x2|half4x3|half4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(float1x1|float1x2|float1x3|float1x4|float2x1|float2x2|float2x3|float2x4|float3x1|float3x2|float3x3|float3x4|float4x1|float4x2|float4x3|float4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(double1x1|double1x2|double1x3|double1x4|double2x1|double2x2|double2x3|double2x4|double3x1|double3x2|double3x3|double3x4|double4x1|double4x2|double4x3|double4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(uint64_t1x1|uint64_t1x2|uint64_t1x3|uint64_t1x4|uint64_t2x1|uint64_t2x2|uint64_t2x3|uint64_t2x4|uint64_t3x1|uint64_t3x2|uint64_t3x3|uint64_t3x4|uint64_t4x1|uint64_t4x2|uint64_t4x3|uint64_t4x4)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(void|string)\\b",
+                    "name": "storage.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "(texture|Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray|Buffer|StructuredBuffer|AppendStructuredBuffer|ConsumeStructuredBuffer|vector|LineStream|PointStream|TriangleStream)<(\\w+)>",
+                    "captures": {
+                        "1": {
+                            "name": "support.type.hlsl.source.dagorsh"
+                        },
+                        "2": { "name": "storage.type.hlsl.source.dagorsh" }
+                    }
+                },
+                {
+                    "match": "\\b(texture|Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray|SamplerState|ByteAddressBuffer|InputPatch|OutputPatch|cbuffer|tbuffer)\\b",
+                    "name": "support.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "(RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D)<(\\w+)>",
+                    "captures": {
+                        "1": {
+                            "name": "support.type.hlsl.source.dagorsh"
+                        },
+                        "2": { "name": "storage.type.hlsl.source.dagorsh" }
+                    }
+                },
+                {
+                    "match": "\\b(RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D)\\b",
+                    "name": "support.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(if|else|while|do|for|switch|continue|case|break|default|return|discard|BRANCH|FLATTEN|LOOP|UNROLL)\\b",
+                    "name": "keyword.control.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(struct|enum|class|namespace|typedef|interface)\\b",
+                    "name": "support.class.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(static|const|unsigned|extern|groupshared|in|inout|out|nointerpolation|noperspective|volatile|column_major|row_major|export|uniform|linear|centroid|nointerpolation|noperspective|sample|inline|precise|snorm|unorm|shared|packoffset|point|line|lineadj|triangle|triangleadj|numthreads)\\b",
+                    "name": "storage.modifier.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "register(\\(\\w+\\))",
+                    "name": "storage.modifier.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "(SV_Coverage|SV_Depth|SV_DepthGreaterEqual|SV_DepthLessEqual|SV_DispatchThreadID|SV_DomainLocation|SV_GroupID|SV_GroupIndex|SV_GroupThreadID|SV_GSInstanceID|SV_InnerCoverage|SV_InsideTessFactor|SV_InstanceID|SV_IsFrontFace|SV_OutputControlPointID|SV_Position|SV_PrimitiveID|SV_RenderTargetArrayIndex|SV_SampleIndex|SV_StencilRef|SV_TessFactor|SV_VertexID|SV_ViewportArrayIndex|SV_ShadingRate|SV_ClipDistance(\\d*)|SV_CullDistance(\\d*)|SV_Target(\\d*))",
+                    "name": "support.type.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(true|false)\\b",
+                    "name": "constant.language.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\b(abort|abs|acos|all|AllMemoryBarrier|AllMemoryBarrierWithGroupSync|any|asdouble|asfloat|asin|asint|asuint|atan|atan2|ceil|CheckAccessFullyMapped|clamp|clip|cos|cosh|countbits|cross|D3DCOLORtoUBYTE4|ddx|ddx_coarse|ddx_fine|ddy|ddy_coarse|ddy_fine|degrees|determinant|DeviceMemoryBarrier|DeviceMemoryBarrierWithGroupSync|distance|dot|dst|errorf|EvaluateAttributeAtCentroid|EvaluateAttributeAtSample|EvaluateAttributeSnapped|exp|exp2|f16tof32|f32tof16|faceforward|firstbithigh|firstbitlow|floor|fma|fmod|frac|frexp|fwidth|GetRenderTargetSampleCount|GetRenderTargetSamplePosition|GroupMemoryBarrier|GroupMemoryBarrierWithGroupSync|InterlockedAdd|InterlockedAnd|InterlockedCompareExchange|InterlockedCompareStore|InterlockedExchange|InterlockedMax|InterlockedMin|InterlockedOr|InterlockedXor|isfinite|isinf|isnan|ldexp|length|lerp|lit|log|log10|log2|mad|max|min|modf|msad4|mul|noise|normalize|pow|printf|Process2DQuadTessFactorsAvg|Process2DQuadTessFactorsMax|Process2DQuadTessFactorsMin|ProcessIsolineTessFactors|ProcessQuadTessFactorsAvg|ProcessQuadTessFactorsMax|ProcessQuadTessFactorsMin|ProcessTriTessFactorsAvg|ProcessTriTessFactorsMax|ProcessTriTessFactorsMin|radians|rcp|reflect|refract|reversebits|round|rsqrt|saturate|sign|sin|sincos|sinh|smoothstep|sqrt|step|tan|tanh|tex1D|tex1Dbias|tex1Dgrad|tex1Dlod|tex1Dproj|tex2D|tex2Dbias|tex2Dgrad|tex2Dlod|tex2Dproj|tex3D|tex3Dbias|tex3Dgrad|tex3Dlod|tex3Dproj|texCUBE|texCUBEbias|texCUBEgrad|texCUBElod|texCUBEproj|transpose|trunc)\\b",
+                    "name": "support.function.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\s*##[^ ]*",
+                    "name": "keyword.control.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "\\s*(#include)\\s*((\\\"|<)\\S+(\\\"|>))",
+                    "captures": {
+                        "1": {
+                            "name": "meta.preprocessor keyword.dagormacro.hlsl.source.dagorsh"
+                        },
+                        "2": {
+                            "name": "string.quoted.double.source.dagorsh"
+                        }
+                    }
+                },
+                {
+                    "match": "\\s*#[^#][^ ]*",
+                    "name": "meta.preprocessor keyword.dagormacro.hlsl.source.dagorsh"
+                },
+                {
+                    "match": "(NULL)",
+                    "name": "constant.language.source.dagorsh"
+                },
+                {
+                    "include": "#numbers"
+                },
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#binding_types"
+                },
+                {
+                    "begin": "{",
+                    "end": "}",
+                    "patterns": [
+                        {
+                            "include": "#hlsl"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -144,7 +144,7 @@
                 {
                     "comment": "CONTROL KEYWORD",
                     "name": "keyword.control.dagorsh",
-                    "match": "\\b(if|else|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|use|interval)\\b"
+                    "match": "\\b(if|else|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|interval)\\b"
                 },
                 {
                     "comment": "BLOCK KEYWORD",
@@ -193,12 +193,12 @@
                 {
                     "comment": "NON-PRIMITIVE TYPE",
                     "name": "storage.type.dagorsh",
-                    "match": "(?<!\\.(?:\\s|/\\*.*?\\*/)*)\\b(texture|buffer|const_buffer)\\b"
+                    "match": "(?<!\\.(?:\\s|/\\*.*?\\*/)*)\\b(texture|buffer|const_buffer|sampler)\\b"
                 },
                 {
                     "comment": "PRIMITIVE TYPE",
                     "name": "storage.type.dagorsh",
-                    "match": "\\b(color8|float1|float2|float3|float4|float|int|int4|short2|short4|ubyte4|short2n|short4n|ushort2n|ushort4n|half2|half4|udec3|dec3n)\\b"
+                    "match": "\\b(bool|float|float1|float2|float3|float4|float4x4|int|int4|color8|short2|short4|ubyte4|short2n|short4n|ushort2n|ushort4n|half2|half4|udec3|dec3n)\\b"
                 }
             ]
         },
@@ -207,7 +207,7 @@
                 {
                     "comment": "NON-PRIMITIVE SHORT TYPE",
                     "name": "storage.type.dagorsh",
-                    "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|static(Cube|TexArray)?|shd|buf|cbuf|uav)\\b"
+                    "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|static(Cube|TexArray)?|shd|buf|cbuf|uav|sampler)\\b"
                 },
                 {
                     "comment": "PRIMITIVE SHORT TYPE",

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -1,6 +1,7 @@
 {
     "scopeName": "source.dagorsh",
     "name": "Dagor Shader Language",
+    "fileTypes": ["sh"],
     "patterns": [
         { "include": "#block" },
         { "include": "#hlsl-block" },
@@ -58,7 +59,7 @@
                 },
                 {
                     "comment": "CULL MODE",
-                    "match": "\\b(cull_mode)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(ccw|cw|none|cullmd))?\\b",
+                    "match": "\\b(cull_mode)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(ccw|cw|none))?\\b",
                     "captures": {
                         "1": { "name": "support.variable.dagorsh" },
                         "3": { "name": "comment.block.dagorsh" },
@@ -143,7 +144,7 @@
                 {
                     "comment": "CONTROL KEYWORD",
                     "name": "keyword.control.dagorsh",
-                    "match": "\\b(if|else|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|use)\\b"
+                    "match": "\\b(if|else|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|use|interval)\\b"
                 },
                 {
                     "comment": "BLOCK KEYWORD",
@@ -159,7 +160,7 @@
                 {
                     "comment": "OTHER KEYWORD",
                     "name": "keyword.other.dagorsh",
-                    "match": "\\b(macro|define_macro_if_not_defined|endmacro|shader|block|supports|interval)\\b"
+                    "match": "\\b(macro|define_macro_if_not_defined|endmacro|shader|block|supports)\\b"
                 }
             ]
         },
@@ -176,7 +177,7 @@
         "modifier": {
             "comment": "MODIFIER",
             "name": "storage.modifier.dagorsh",
-            "match": "\\b(always_referenced|static|dynamic|local|channel|no_warnings|const|undefined_value|public)\\b"
+            "match": "\\b(always_referenced|static|dynamic|local|channel|no_warnings|const|undefined_value|public|signed_pack|unsigned_pack|mul_1k|mul_2k|mul_4k|mul_8k|mul_16k|mul_32767|bounding_pack)\\b"
         },
         "function": {
             "comment": "FUNCTION",
@@ -191,7 +192,7 @@
             "patterns": [
                 {
                     "comment": "NON-PRIMITIVE TYPE",
-                    "name": "support.class.dagorsh",
+                    "name": "storage.type.dagorsh",
                     "match": "(?<!\\.(?:\\s|/\\*.*?\\*/)*)\\b(texture|buffer|const_buffer)\\b"
                 },
                 {
@@ -205,8 +206,8 @@
             "patterns": [
                 {
                     "comment": "NON-PRIMITIVE SHORT TYPE",
-                    "name": "support.class.dagorsh",
-                    "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|static(Cube|TexArray)?|shd|buf|cbuf|uav|vsf|vsmp|psf|csf|ps_buf|vs_buf|cs_buf|ps_cbuf|vs_cbuf|cs_cbuf)\\b"
+                    "name": "storage.type.dagorsh",
+                    "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|static(Cube|TexArray)?|shd|buf|cbuf|uav)\\b"
                 },
                 {
                     "comment": "PRIMITIVE SHORT TYPE",
@@ -216,18 +217,9 @@
             ]
         },
         "variable": {
-            "patterns": [
-                {
-                    "comment": "BUILT-IN VARIABLE",
-                    "name": "support.variable.dagorsh",
-                    "match": "\\b(alpha_to_coverage|z_write|z_test|stencil|view_instances|stencil_ref|slope_z_bias|z_bias|two_sided|real_two_sided|globtm|projtm|viewprojtm|local_view_x|local_view_y|local_view_z|local_view_pos|world_local_x|world_local_y|world_local_z|world_local_pos|vpr_const_array)\\b"
-                },
-                {
-                    "comment": "VARIABLE",
-                    "name": "variable.dagorsh",
-                    "match": "[a-zA-Z_]\\w*"
-                }
-            ]
+            "comment": "VARIABLE",
+            "name": "variable.dagorsh",
+            "match": "[a-zA-Z_]\\w*"
         },
         "test": {
             "comment": "ONLY FOR DEBUGGING THE GRAMMAR",

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -44,6 +44,61 @@
                     "comment": "BOOL AND NULL LITERAL",
                     "name": "constant.language.dagorsh",
                     "match": "\\b(true|false|NULL)\\b"
+                },
+                {
+                    "comment": "BLEND",
+                    "match": "\\b(blend_(asrc|adst|src|dst))(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(zero|one|sc|isc|sa|isa|da|ida|dc|idc|sasat|bf|ibf))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "4": { "name": "comment.block.dagorsh" },
+                        "6": { "name": "keyword.operator.dagorsh" },
+                        "7": { "name": "comment.block.dagorsh" },
+                        "9": { "name": "constant.language.dagorsh" }
+                    }
+                },
+                {
+                    "comment": "CULL MODE",
+                    "match": "\\b(cull_mode)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(ccw|cw|none|cullmd))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
+                },
+                {
+                    "comment": "DEPTH AND STENCIL FUNC",
+                    "match": "\\b(z_func|stencil_func)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(never|less|equal|lessequal|greater|notequal|greaterequal|always))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
+                },
+                {
+                    "comment": "STENCIL",
+                    "match": "\\b(stencil_pass|stencil_fail|stencil_zfail)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(keep|zero|replace|incrsat|decrsat|incr|dect))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
+                },
+                {
+                    "comment": "COLOR WRITE",
+                    "match": "\\b(color_write)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)([rgba]{1,4}))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
                 }
             ]
         },
@@ -105,61 +160,6 @@
                     "comment": "OTHER KEYWORD",
                     "name": "keyword.other.dagorsh",
                     "match": "\\b(macro|define_macro_if_not_defined|endmacro|shader|block)\\b"
-                },
-                {
-                    "comment": "BLEND",
-                    "match": "\\b(blend_(asrc|adst|src|dst))(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(zero|one|sc|isc|sa|isa|da|ida|dc|idc|sasat|bf|ibf))?\\b",
-                    "captures": {
-                        "1": { "name": "support.variable.dagorsh" },
-                        "4": { "name": "comment.block.dagorsh" },
-                        "6": { "name": "keyword.operator.dagorsh" },
-                        "7": { "name": "comment.block.dagorsh" },
-                        "9": { "name": "constant.language.dagorsh" }
-                    }
-                },
-                {
-                    "comment": "CULL MODE",
-                    "match": "\\b(cull_mode)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(ccw|cw|none|cullmd))?\\b",
-                    "captures": {
-                        "1": { "name": "support.variable.dagorsh" },
-                        "3": { "name": "comment.block.dagorsh" },
-                        "5": { "name": "keyword.operator.dagorsh" },
-                        "6": { "name": "comment.block.dagorsh" },
-                        "8": { "name": "constant.language.dagorsh" }
-                    }
-                },
-                {
-                    "comment": "DEPTH AND STENCIL FUNC",
-                    "match": "\\b(z_func|stencil_func)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(never|less|equal|lessequal|greater|notequal|greaterequal|always))?\\b",
-                    "captures": {
-                        "1": { "name": "support.variable.dagorsh" },
-                        "3": { "name": "comment.block.dagorsh" },
-                        "5": { "name": "keyword.operator.dagorsh" },
-                        "6": { "name": "comment.block.dagorsh" },
-                        "8": { "name": "constant.language.dagorsh" }
-                    }
-                },
-                {
-                    "comment": "STENCIL",
-                    "match": "\\b(stencil_pass|stencil_fail|stencil_zfail)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(keep|zero|replace|incrsat|decrsat|incr|dect))?\\b",
-                    "captures": {
-                        "1": { "name": "support.variable.dagorsh" },
-                        "3": { "name": "comment.block.dagorsh" },
-                        "5": { "name": "keyword.operator.dagorsh" },
-                        "6": { "name": "comment.block.dagorsh" },
-                        "8": { "name": "constant.language.dagorsh" }
-                    }
-                },
-                {
-                    "comment": "COLOR WRITE",
-                    "match": "\\b(color_write)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)([rgba]{1,4}))?\\b",
-                    "captures": {
-                        "1": { "name": "support.variable.dagorsh" },
-                        "3": { "name": "comment.block.dagorsh" },
-                        "5": { "name": "keyword.operator.dagorsh" },
-                        "6": { "name": "comment.block.dagorsh" },
-                        "8": { "name": "constant.language.dagorsh" }
-                    }
                 }
             ]
         },

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -31,10 +31,10 @@
             "begin": "{",
             "end": "}",
             "beginCaptures": {
-                "0": { "name": "punctuation.hlsl" }
+                "0": { "name": "punctuation.dagorsh" }
             },
             "endCaptures": {
-                "0": { "name": "punctuation.hlsl" }
+                "0": { "name": "punctuation.dagorsh" }
             },
             "patterns": [{ "include": "$self" }]
         },
@@ -143,7 +143,7 @@
                 {
                     "comment": "CONTROL KEYWORD",
                     "name": "keyword.control.dagorsh",
-                    "match": "\\b(if|else|supports|interval|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|use)\\b"
+                    "match": "\\b(if|else|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|use)\\b"
                 },
                 {
                     "comment": "BLOCK KEYWORD",
@@ -151,7 +151,7 @@
                     "captures": {
                         "1": { "name": "keyword.other.dagorsh" },
                         "3": { "name": "comment.block.dagorsh" },
-                        "5": { "name": "keyword.operator.hlsl" },
+                        "5": { "name": "keyword.operator.dagorsh" },
                         "6": { "name": "comment.block.dagorsh" },
                         "8": { "name": "constant.language.dagorsh" }
                     }
@@ -159,7 +159,7 @@
                 {
                     "comment": "OTHER KEYWORD",
                     "name": "keyword.other.dagorsh",
-                    "match": "\\b(macro|define_macro_if_not_defined|endmacro|shader|block)\\b"
+                    "match": "\\b(macro|define_macro_if_not_defined|endmacro|shader|block|supports|interval)\\b"
                 }
             ]
         },

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -1,608 +1,238 @@
 {
     "scopeName": "source.dagorsh",
-    "name": "DagorShader",
-    "fileTypes": ["sh"],
+    "name": "Dagor Shader Language",
     "patterns": [
-        {
-            "include": "#macro_block"
-        },
-        {
-            "include": "#strings"
-        },
-        {
-            "include": "#comments"
-        },
-        {
-            "include": "#hlsl_block"
-        },
-        {
-            "include": "#block_block"
-        },
-        {
-            "include": "#shader_variables"
-        },
-        {
-            "include": "#shader_block"
-        },
-        {
-            "include": "#shader_ops"
-        }
+        { "include": "#block" },
+        { "include": "#hlsl-block" },
+        { "include": "#comment" },
+        { "include": "#string-literal" },
+        { "include": "#number-literal" },
+        { "include": "#bool-null-literal" },
+        { "include": "#short-type" },
+        { "include": "#modifier" },
+        { "include": "#keyword" },
+        { "include": "#stage" },
+        { "include": "#operator" },
+        { "include": "#function" },
+        { "include": "#type" },
+        { "include": "#variable" }
     ],
     "repository": {
-        "macro_block": {
+        "hlsl-block": {
+            "begin": "\\b(hlsl)\\b",
+            "end": "(?<=})",
+            "beginCaptures": {
+                "0": { "name": "keyword.other.dagorsh" }
+            },
+            "patterns": [{ "include": "#stage" }, { "include": "source.hlsl" }]
+        },
+        "block": {
+            "comment": "BLOCK",
+            "begin": "{",
+            "end": "}",
+            "beginCaptures": {
+                "0": { "name": "punctuation.hlsl" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.hlsl" }
+            },
+            "patterns": [{ "include": "$self" }]
+        },
+        "bool-null-literal": {
             "patterns": [
                 {
-                    "begin": "\\b(macro|define_macro_if_not_defined)\\s*(\\w+)\\b",
-                    "end": "\\b(endmacro)\\b",
-                    "captures": {
-                        "1": { "name": "keyword.other.source.dagorsh" },
-                        "2": { "name": "name.macro.source.dagor" }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#comments"
-                        },
-                        {
-                            "include": "#strings"
-                        },
-                        {
-                            "include": "#binding_types"
-                        },
-                        {
-                            "include": "#hlsl_block"
-                        },
-                        {
-                            "include": "#declaration_block"
-                        },
-                        {
-                            "include": "#shader_variables"
-                        },
-                        {
-                            "include": "#shader_ops"
-                        },
-                        {
-                            "include": "#material_block"
-                        }
-                    ]
+                    "comment": "BOOL AND NULL LITERAL",
+                    "name": "constant.language.dagorsh",
+                    "match": "\\b(true|false|NULL)\\b"
                 }
             ]
         },
-        "material_ops": {
+        "comment": {
             "patterns": [
                 {
-                    "match": "(\\w+)(\\s*)(=)(\\s*)(mat.)(ambient|diffuse|emissive|specular)(\\s*)(;)",
-                    "captures": {
-                        "1": { "name": "variable.source.dagorsh" },
-                        "5": { "name": "support.constant.source.dagorsh" },
-                        "6": { "name": "support.constant.source.dagorsh" }
-                    }
-                },
-                {
-                    "match": "(\\w+)(\\s*)(=)(\\s*)(mat.texture.)(\\s*)(\\w+)(;)",
-                    "captures": {
-                        "1": { "name": "variable.source.dagorsh" },
-                        "5": { "name": "support.constant.source.dagorsh" },
-                        "7": { "name": "support.constant.source.dagorsh" }
-                    }
-                }
-            ]
-        },
-        "material_block": {
-            "patterns": [
-                {
-                    "begin": "\\b(init)\\b",
-                    "end": "(?<=})",
-                    "beginCaptures": {
-                        "1": { "name": "support.class.source.dagor" }
-                    },
-                    "patterns": [
-                        {
-                            "begin": "({)",
-                            "end": "(})",
-                            "patterns": [
-                                {
-                                    "include": "#comments"
-                                },
-                                {
-                                    "include": "#strings"
-                                },
-                                {
-                                    "include": "#material_ops"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "numbers": {
-            "patterns": [
-                {
-                    "match": "\\b([0-9]+\\.?[0-9]*(f?F?h?H?l?L?|e-?[0-9]+))\\b",
-                    "name": "constant.numeric.source.dagorsh"
-                }
-            ]
-        },
-        "shader_ops": {
-            "patterns": [
-                {
-                    "match": "\\b(blend_asrc|blend_adst|blend_src|blend_dst|cull_mode|alpha_to_coverage|view_instances|z_write|z_test|z_func|stencil|stencil_func|stencil_ref|stencil_pass|stencil_fail|stencil_zfail|color_write|slope_z_bias|z_bias)\\b",
-                    "name": "support.variable.source.dagorsh"
-                },
-                {
-                    "match": "\\b(color8|float1|float2|float3|float4|short2|short4|ubyte4|short2n|short4n|ushort2n|ushort4n|half2|half4|udec3|dec3n|extra|norm|pos|tc|vcol|signed_pack|unsigned_pack|mul_1k|mul_2k|mul_4k|mul_8k|mul_16k|mul_32767|bounding_pack)\\b",
-                    "name": "support.variable.source.dagorsh"
-                },
-                {
-                    "match": "\\b(two_sided|real_two_sided|true|false|globtm|projtm|viewprojtm|local_view_x|local_view_y|local_view_z|local_view_pos|world_local_x|world_local_y|world_local_z|world_local_pos|vpr_const_array)\\b",
-                    "name": "support.constant.source.dagorsh"
-                },
-                {
-                    "match": "\\b(zero|one|sc|isc|sa|isa|da|ida|dc|idc|sasat|bf|ibf)\\b",
-                    "name": "support.constant.source.dagorsh"
-                },
-                {
-                    "match": "\\b(keep|zero|replace|incrsat|decrsat|incr|dect)\\b",
-                    "name": "support.constant.source.dagorsh"
-                },
-                {
-                    "match": "\\b(never|less|equal|lessequal|greater|notequal|greaterequal|always)\\b",
-                    "name": "support.constant.source.dagorsh"
-                },
-                {
-                    "match": "\\b(cw|ccw|none)\\b",
-                    "name": "support.constant.source.dagorsh"
-                },
-                {
-                    "match": "\\b(include|include_optional|compile|channel|render_stage|supports|use)\\b",
-                    "name": "keyword.other.source.dagorsh"
-                },
-                {
-                    "match": "\\b(interval|dont_render|no_dynstcode|render_trans|no_ablend|assume)\\b",
-                    "name": "keyword.control.source.dagorsh"
-                },
-                {
-                    "match": "\\b(if|else)\\b",
-                    "name": "keyword.control.source.dagorsh"
-                },
-                {
-                    "match": "(NULL)",
-                    "name": "constant.language.source.dagorsh"
-                },
-                {
-                    "include": "#declaration_block"
-                },
-                {
-                    "include": "#numbers"
-                },
-                {
-                    "include": "#strings"
-                },
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#hlsl_block"
-                },
-                {
-                    "begin": "{",
-                    "end": "}",
-                    "patterns": [
-                        {
-                            "include": "#shader_ops"
-                        }
-                    ]
-                }
-            ]
-        },
-        "shader_variables": {
-            "patterns": [
-                {
-                    "match": "\\b(int|int4|float|float4|float4x4|texture|buffer|const_buffer|define|undef)\\b",
-                    "name": "support.type.source.dagorsh"
-                },
-                {
-                    "match": "\\b(local|dynamic|static|const|always_referenced|undefined_value|no_warnings|public)\\b",
-                    "name": "storage.modifier.source.dagorsh"
-                }
-            ]
-        },
-        "comments": {
-            "patterns": [
-                {
-                    "begin": "//",
-                    "end": "$",
-                    "name": "comment.line.double-slash.source.dagorsh"
-                },
-                {
+                    "comment": "MULTI LINE COMMENT",
+                    "name": "comment.block.dagorsh",
                     "begin": "/\\*",
-                    "end": "\\*/",
-                    "name": "comment.line.block.source.dagorsh"
+                    "end": "\\*/"
+                },
+                {
+                    "comment": "SINGLE LINE COMMENT",
+                    "name": "comment.line.double-slash.dagorsh",
+                    "begin": "//",
+                    "end": "$"
                 }
             ]
         },
-        "strings": {
+        "string-literal": {
+            "comment": "STRING LITERAL",
+            "name": "string.quoted.double.dagorsh",
+            "begin": "\"",
+            "end": "\""
+        },
+        "number-literal": {
             "patterns": [
                 {
-                    "begin": "\"",
-                    "end": "\"",
-                    "name": "string.quoted.double.source.dagorsh"
+                    "comment": "FLOATING POINT LITERAL",
+                    "name": "constant.numeric.dagorsh",
+                    "match": "((\\d+?\\.\\d+|\\d+\\.)([eE][+-]?\\d+)?|\\d+[eE][+-]?\\d+)[hHfFlL]?"
+                },
+                {
+                    "comment": "FIXED POINT LITERAL",
+                    "name": "constant.numeric.dagorsh",
+                    "match": "(0[xX](\\d|[a-fA-F])+|[1-9]\\d*|0[0-7]*)[uUlL]?"
                 }
             ]
         },
-        "binding_types": {
+        "keyword": {
             "patterns": [
                 {
-                    "match": "(@)(static|vsf|vsmp|psf|shd|smp(2d|3d|Array|Cube)?|tex(2d|3d|Array|Cube)?|csf|ps_buf|vs_buf|cs_buf|ps_cbuf|vs_cbuf|cs_cbuf|buf|f(1|2|3|4+)|i(1|2|3|4))",
-                    "name": "support.type.source.dagorsh"
-                }
-            ]
-        },
-        "declaration_block": {
-            "patterns": [
-                {
-                    "include": "#declaration_block_a"
+                    "comment": "CONTROL KEYWORD",
+                    "name": "keyword.control.dagorsh",
+                    "match": "\\b(if|else|supports|interval|compile|include|include_optional|assume|dont_render|no_dynstcode|render_trans|no_ablend|render_stage|use)\\b"
                 },
                 {
-                    "include": "#declaration_block_b"
-                }
-            ]
-        },
-        "declaration_block_a": {
-            "patterns": [
-                {
-                    "begin": "^\\s*(\\(\\w+\\))\\s*{",
-                    "end": "(?<=})",
-                    "beginCaptures": {
-                        "1": { "name": "support.class.hlsl.source.dagor" }
-                    },
-                    "patterns": [
-                        {
-                            "match": "\\b(if|else)\\b",
-                            "name": "keyword.control.source.dagorsh"
-                        },
-                        {
-                            "include": "#comments"
-                        },
-                        {
-                            "include": "#strings"
-                        },
-                        {
-                            "include": "#numbers"
-                        },
-                        {
-                            "include": "#binding_types"
-                        },
-                        {
-                            "include": "#hlsl_block"
-                        },
-                        {
-                            "include": "#declaration_block_body"
-                        }
-                    ]
-                }
-            ]
-        },
-        "declaration_block_b": {
-            "patterns": [
-                {
-                    "begin": "^\\s*(\\(\\w+\\))\\s*$",
-                    "end": "(?<=})",
-                    "beginCaptures": {
-                        "1": { "name": "support.class.hlsl.source.dagor" }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#declaration_block_body"
-                        }
-                    ]
-                }
-            ]
-        },
-        "declaration_block_body": {
-            "patterns": [
-                {
-                    "begin": "({)",
-                    "end": "(})",
-                    "patterns": [
-                        {
-                            "match": "\\b(if|else)\\b",
-                            "name": "keyword.control.source.dagorsh"
-                        },
-                        {
-                            "include": "#comments"
-                        },
-                        {
-                            "include": "#strings"
-                        },
-                        {
-                            "include": "#numbers"
-                        },
-                        {
-                            "include": "#binding_types"
-                        },
-                        {
-                            "include": "#hlsl_block"
-                        },
-                        {
-                            "include": "#declaration_block_body"
-                        }
-                    ]
-                }
-            ]
-        },
-        "shader_block": {
-            "patterns": [
-                {
-                    "begin": "\\b(shader)\\s*(\\w+)((,\\s*\\w+)*)\\b",
-                    "end": "(?<=})",
-                    "beginCaptures": {
-                        "1": { "name": "support.class.source.dagor" },
-                        "2": { "name": "name.source.dagorsh" },
-                        "3": { "name": "name.source.dagorsh" }
-                    },
-                    "patterns": [
-                        {
-                            "begin": "({)",
-                            "end": "(})",
-                            "patterns": [
-                                {
-                                    "include": "#comments"
-                                },
-                                {
-                                    "include": "#strings"
-                                },
-                                {
-                                    "include": "#shader_ops"
-                                },
-                                {
-                                    "include": "#declaration_block"
-                                },
-                                {
-                                    "include": "#hlsl_block"
-                                },
-                                {
-                                    "include": "#shader_variables"
-                                },
-                                {
-                                    "include": "#material_block"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "block_block": {
-            "patterns": [
-                {
-                    "begin": "(block)(\\(\\w+\\))(\\s*)(\\w+)",
-                    "end": "(?<=})",
-                    "beginCaptures": {
-                        "1": { "name": "support.class.source.dagor" },
-                        "2": { "name": "support.class.source.dagor" },
-                        "4": { "name": "name.block.source.dagor" }
-                    },
-                    "patterns": [
-                        {
-                            "begin": "({)",
-                            "end": "(})",
-                            "patterns": [
-                                {
-                                    "include": "#comments"
-                                },
-                                {
-                                    "include": "#strings"
-                                },
-                                {
-                                    "include": "#shader_ops"
-                                },
-                                {
-                                    "include": "#declaration_block"
-                                },
-                                {
-                                    "include": "#hlsl_block"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "hlsl_block": {
-            "patterns": [
-                {
-                    "begin": "(\\(\\w+\\)|)\\s*(hlsl)\\s*(\\(\\w+\\)|)",
-                    "end": "(?<=})",
-                    "beginCaptures": {
-                        "1": { "name": "support.class.hlsl.source.dagor" },
-                        "2": { "name": "support.class.hlsl.source.dagor" },
-                        "3": { "name": "support.class.hlsl.source.dagor" }
-                    },
-                    "patterns": [
-                        {
-                            "begin": "({)",
-                            "end": "(})",
-                            "patterns": [
-                                {
-                                    "include": "#hlsl"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "hlsl": {
-            "patterns": [
-                {
-                    "match": "\\b(bool|bool1|bool2|bool3|bool4)\\b",
-                    "name": "storage.type.hlsl.source.dagorshj"
-                },
-                {
-                    "match": "\\b(int|int1|int2|int3|int4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(uint|uint1|uint2|uint3|uint4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(dword|dword1|dword2|dword3|dword4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(half|half1|half2|half3|half4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(float|float1|float2|float3|float4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(double|double1|double2|double3|double4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(uint64_t|uint64_t1|uint64_t2|uint64_t3|uint64_t4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(matrix)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(bool1x1|bool1x2|bool1x3|bool1x4|bool2x1|bool2x2|bool2x3|bool2x4|bool3x1|bool3x2|bool3x3|bool3x4|bool4x1|bool4x2|bool4x3|bool4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(int1x1|int1x2|int1x3|int1x4|int2x1|int2x2|int2x3|int2x4|int3x1|int3x2|int3x3|int3x4|int4x1|int4x2|int4x3|int4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(uint1x1|uint1x2|uint1x3|uint1x4|uint2x1|uint2x2|uint2x3|uint2x4|uint3x1|uint3x2|uint3x3|uint3x4|uint4x1|uint4x2|uint4x3|uint4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(dword1x1|dword1x2|dword1x3|dword1x4|dword2x1|dword2x2|dword2x3|dword2x4|dword3x1|dword3x2|dword3x3|dword3x4|dword4x1|dword4x2|dword4x3|dword4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(half1x1|half1x2|half1x3|half1x4|half2x1|half2x2|half2x3|half2x4|half3x1|half3x2|half3x3|half3x4|half4x1|half4x2|half4x3|half4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(float1x1|float1x2|float1x3|float1x4|float2x1|float2x2|float2x3|float2x4|float3x1|float3x2|float3x3|float3x4|float4x1|float4x2|float4x3|float4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(double1x1|double1x2|double1x3|double1x4|double2x1|double2x2|double2x3|double2x4|double3x1|double3x2|double3x3|double3x4|double4x1|double4x2|double4x3|double4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(uint64_t1x1|uint64_t1x2|uint64_t1x3|uint64_t1x4|uint64_t2x1|uint64_t2x2|uint64_t2x3|uint64_t2x4|uint64_t3x1|uint64_t3x2|uint64_t3x3|uint64_t3x4|uint64_t4x1|uint64_t4x2|uint64_t4x3|uint64_t4x4)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(void|string)\\b",
-                    "name": "storage.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "(texture|Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray|Buffer|StructuredBuffer|AppendStructuredBuffer|ConsumeStructuredBuffer|vector|LineStream|PointStream|TriangleStream)<(\\w+)>",
+                    "comment": "BLOCK KEYWORD",
+                    "match": "\\b(block)(((\\s|/\\*.*?\\*/)*)(\\()((\\s|/\\*.*?\\*/)*)(frame|global_const|scene|object)\\b)?",
                     "captures": {
-                        "1": {
-                            "name": "support.type.hlsl.source.dagorsh"
-                        },
-                        "2": { "name": "storage.type.hlsl.source.dagorsh" }
+                        "1": { "name": "keyword.other.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.hlsl" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
                     }
                 },
                 {
-                    "match": "\\b(texture|Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray|SamplerState|ByteAddressBuffer|InputPatch|OutputPatch|cbuffer|tbuffer)\\b",
-                    "name": "support.type.hlsl.source.dagorsh"
+                    "comment": "OTHER KEYWORD",
+                    "name": "keyword.other.dagorsh",
+                    "match": "\\b(macro|define_macro_if_not_defined|endmacro|shader|block)\\b"
                 },
                 {
-                    "match": "(RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D)<(\\w+)>",
+                    "comment": "BLEND",
+                    "match": "\\b(blend_(asrc|adst|src|dst))(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(zero|one|sc|isc|sa|isa|da|ida|dc|idc|sasat|bf|ibf))?\\b",
                     "captures": {
-                        "1": {
-                            "name": "support.type.hlsl.source.dagorsh"
-                        },
-                        "2": { "name": "storage.type.hlsl.source.dagorsh" }
+                        "1": { "name": "support.variable.dagorsh" },
+                        "4": { "name": "comment.block.dagorsh" },
+                        "6": { "name": "keyword.operator.dagorsh" },
+                        "7": { "name": "comment.block.dagorsh" },
+                        "9": { "name": "constant.language.dagorsh" }
                     }
                 },
                 {
-                    "match": "\\b(RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D)\\b",
-                    "name": "support.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(if|else|while|do|for|switch|continue|case|break|default|return|discard|BRANCH|FLATTEN|LOOP|UNROLL)\\b",
-                    "name": "keyword.control.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(struct|enum|class|namespace|typedef|interface)\\b",
-                    "name": "support.class.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(static|const|unsigned|extern|groupshared|in|inout|out|nointerpolation|noperspective|volatile|column_major|row_major|export|uniform|linear|centroid|nointerpolation|noperspective|sample|inline|precise|snorm|unorm|shared|packoffset|point|line|lineadj|triangle|triangleadj|numthreads)\\b",
-                    "name": "storage.modifier.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "register(\\(\\w+\\))",
-                    "name": "storage.modifier.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "(SV_Coverage|SV_Depth|SV_DepthGreaterEqual|SV_DepthLessEqual|SV_DispatchThreadID|SV_DomainLocation|SV_GroupID|SV_GroupIndex|SV_GroupThreadID|SV_GSInstanceID|SV_InnerCoverage|SV_InsideTessFactor|SV_InstanceID|SV_IsFrontFace|SV_OutputControlPointID|SV_Position|SV_PrimitiveID|SV_RenderTargetArrayIndex|SV_SampleIndex|SV_StencilRef|SV_TessFactor|SV_VertexID|SV_ViewportArrayIndex|SV_ShadingRate|SV_ClipDistance(\\d*)|SV_CullDistance(\\d*)|SV_Target(\\d*))",
-                    "name": "support.type.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(true|false)\\b",
-                    "name": "constant.language.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\b(abort|abs|acos|all|AllMemoryBarrier|AllMemoryBarrierWithGroupSync|any|asdouble|asfloat|asin|asint|asuint|atan|atan2|ceil|CheckAccessFullyMapped|clamp|clip|cos|cosh|countbits|cross|D3DCOLORtoUBYTE4|ddx|ddx_coarse|ddx_fine|ddy|ddy_coarse|ddy_fine|degrees|determinant|DeviceMemoryBarrier|DeviceMemoryBarrierWithGroupSync|distance|dot|dst|errorf|EvaluateAttributeAtCentroid|EvaluateAttributeAtSample|EvaluateAttributeSnapped|exp|exp2|f16tof32|f32tof16|faceforward|firstbithigh|firstbitlow|floor|fma|fmod|frac|frexp|fwidth|GetRenderTargetSampleCount|GetRenderTargetSamplePosition|GroupMemoryBarrier|GroupMemoryBarrierWithGroupSync|InterlockedAdd|InterlockedAnd|InterlockedCompareExchange|InterlockedCompareStore|InterlockedExchange|InterlockedMax|InterlockedMin|InterlockedOr|InterlockedXor|isfinite|isinf|isnan|ldexp|length|lerp|lit|log|log10|log2|mad|max|min|modf|msad4|mul|noise|normalize|pow|printf|Process2DQuadTessFactorsAvg|Process2DQuadTessFactorsMax|Process2DQuadTessFactorsMin|ProcessIsolineTessFactors|ProcessQuadTessFactorsAvg|ProcessQuadTessFactorsMax|ProcessQuadTessFactorsMin|ProcessTriTessFactorsAvg|ProcessTriTessFactorsMax|ProcessTriTessFactorsMin|radians|rcp|reflect|refract|reversebits|round|rsqrt|saturate|sign|sin|sincos|sinh|smoothstep|sqrt|step|tan|tanh|tex1D|tex1Dbias|tex1Dgrad|tex1Dlod|tex1Dproj|tex2D|tex2Dbias|tex2Dgrad|tex2Dlod|tex2Dproj|tex3D|tex3Dbias|tex3Dgrad|tex3Dlod|tex3Dproj|texCUBE|texCUBEbias|texCUBEgrad|texCUBElod|texCUBEproj|transpose|trunc)\\b",
-                    "name": "support.function.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\s*##[^ ]*",
-                    "name": "keyword.control.hlsl.source.dagorsh"
-                },
-                {
-                    "match": "\\s*(#include)\\s*((\\\"|<)\\S+(\\\"|>))",
+                    "comment": "CULL MODE",
+                    "match": "\\b(cull_mode)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(ccw|cw|none|cullmd))?\\b",
                     "captures": {
-                        "1": {
-                            "name": "meta.preprocessor keyword.dagormacro.hlsl.source.dagorsh"
-                        },
-                        "2": {
-                            "name": "string.quoted.double.source.dagorsh"
-                        }
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
                     }
                 },
                 {
-                    "match": "\\s*#[^#][^ ]*",
-                    "name": "meta.preprocessor keyword.dagormacro.hlsl.source.dagorsh"
+                    "comment": "DEPTH AND STENCIL FUNC",
+                    "match": "\\b(z_func|stencil_func)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(never|less|equal|lessequal|greater|notequal|greaterequal|always))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
                 },
                 {
-                    "match": "(NULL)",
-                    "name": "constant.language.source.dagorsh"
+                    "comment": "STENCIL",
+                    "match": "\\b(stencil_pass|stencil_fail|stencil_zfail)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)(keep|zero|replace|incrsat|decrsat|incr|dect))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
                 },
                 {
-                    "include": "#numbers"
-                },
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#binding_types"
-                },
-                {
-                    "begin": "{",
-                    "end": "}",
-                    "patterns": [
-                        {
-                            "include": "#hlsl"
-                        }
-                    ]
+                    "comment": "COLOR WRITE",
+                    "match": "\\b(color_write)(((\\s|/\\*.*?\\*/)*)(=)((\\s|/\\*.*?\\*/)*)([rgba]{1,4}))?\\b",
+                    "captures": {
+                        "1": { "name": "support.variable.dagorsh" },
+                        "3": { "name": "comment.block.dagorsh" },
+                        "5": { "name": "keyword.operator.dagorsh" },
+                        "6": { "name": "comment.block.dagorsh" },
+                        "8": { "name": "constant.language.dagorsh" }
+                    }
                 }
             ]
+        },
+        "stage": {
+            "comment": "STAGE",
+            "name": "constant.language.dagorsh",
+            "match": "(?<=\\((\\s|/\\*.*?\\*/)*)(vs|hs|ds|gs|ps|cs)(?=(\\s|/\\*.*?\\*/)*\\))"
+        },
+        "operator": {
+            "comment": "OPERATOR",
+            "name": "keyword.operator.dagorsh",
+            "match": "[+\\-*/%\\[\\]~<>&|^?:(),.!=;]"
+        },
+        "modifier": {
+            "comment": "MODIFIER",
+            "name": "storage.modifier.dagorsh",
+            "match": "\\b(always_referenced|static|dynamic|local|channel|no_warnings|const|undefined_value|public)\\b"
+        },
+        "function": {
+            "comment": "FUNCTION",
+            "match": "\\b([a-zA-Z_]\\w*)((\\s|/\\*.*?\\*/)*)(\\()",
+            "captures": {
+                "1": { "name": "entity.name.function.dagorsh" },
+                "2": { "name": "comment.block.dagorsh" },
+                "4": { "name": "keyword.operator.dagorsh" }
+            }
+        },
+        "type": {
+            "patterns": [
+                {
+                    "comment": "NON-PRIMITIVE TYPE",
+                    "name": "support.class.dagorsh",
+                    "match": "(?<!\\.(?:\\s|/\\*.*?\\*/)*)\\b(texture|buffer|const_buffer)\\b"
+                },
+                {
+                    "comment": "PRIMITIVE TYPE",
+                    "name": "storage.type.dagorsh",
+                    "match": "\\b(color8|float1|float2|float3|float4|float|int|int4|short2|short4|ubyte4|short2n|short4n|ushort2n|ushort4n|half2|half4|udec3|dec3n)\\b"
+                }
+            ]
+        },
+        "short-type": {
+            "patterns": [
+                {
+                    "comment": "NON-PRIMITIVE SHORT TYPE",
+                    "name": "support.class.dagorsh",
+                    "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|static(Cube|TexArray)?|shd|buf|cbuf|uav|vsf|vsmp|psf|csf|ps_buf|vs_buf|cs_buf|ps_cbuf|vs_cbuf|cs_cbuf)\\b"
+                },
+                {
+                    "comment": "PRIMITIVE SHORT TYPE",
+                    "name": "storage.type.dagorsh",
+                    "match": "@((f|i)[1-4]|f44)\\b"
+                }
+            ]
+        },
+        "variable": {
+            "patterns": [
+                {
+                    "comment": "BUILT-IN VARIABLE",
+                    "name": "support.variable.dagorsh",
+                    "match": "\\b(alpha_to_coverage|z_write|z_test|stencil|view_instances|stencil_ref|slope_z_bias|z_bias|two_sided|real_two_sided|globtm|projtm|viewprojtm|local_view_x|local_view_y|local_view_z|local_view_pos|world_local_x|world_local_y|world_local_z|world_local_pos|vpr_const_array)\\b"
+                },
+                {
+                    "comment": "VARIABLE",
+                    "name": "variable.dagorsh",
+                    "match": "[a-zA-Z_]\\w*"
+                }
+            ]
+        },
+        "test": {
+            "comment": "ONLY FOR DEBUGGING THE GRAMMAR",
+            "name": "invalid.illegal.dagorsh",
+            "match": "."
         }
     }
 }

--- a/grammar/dagorsh.tmLanguage.json
+++ b/grammar/dagorsh.tmLanguage.json
@@ -171,7 +171,7 @@
         "operator": {
             "comment": "OPERATOR",
             "name": "keyword.operator.dagorsh",
-            "match": "[+\\-*/%\\[\\]~<>&|^?:(),.!=;]"
+            "match": "[+\\-*/%\\[\\]~<>&|^?:(),.!=;$]"
         },
         "modifier": {
             "comment": "MODIFIER",

--- a/grammar/hlsl.tmLanguage.json
+++ b/grammar/hlsl.tmLanguage.json
@@ -1,0 +1,385 @@
+{
+    "scopeName": "source.hlsl",
+    "name": "HLSL",
+    "patterns": [
+        { "include": "#block" },
+        { "include": "#comment" },
+        { "include": "#string-char-literal" },
+        { "include": "#line-continuation" },
+        { "include": "#number-literal" },
+        { "include": "#language-constant" },
+        { "include": "#modifier" },
+        { "include": "#preprocessor-directive" },
+        { "include": "#template" },
+        { "include": "#keyword-operator" },
+        { "include": "#type-declaration" },
+        { "include": "#function" },
+        { "include": "#built-in-type" },
+        { "include": "#user-type" },
+        { "include": "#variable" },
+        { "include": "#semicolon" }
+    ],
+    "repository": {
+        "block": {
+            "comment": "BLOCK",
+            "begin": "{",
+            "end": "}",
+            "beginCaptures": {
+                "0": { "name": "punctuation.hlsl" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.hlsl" }
+            },
+            "patterns": [{ "include": "$self" }]
+        },
+        "comment": {
+            "patterns": [
+                {
+                    "comment": "MULTI LINE COMMENT",
+                    "name": "comment.block.hlsl",
+                    "begin": "/\\*",
+                    "end": "\\*/",
+                    "patterns": [
+                        {
+                            "include": "#line-continuation"
+                        }
+                    ]
+                },
+                {
+                    "comment": "SINGLE LINE COMMENT",
+                    "name": "comment.line.double-slash.hlsl",
+                    "begin": "//",
+                    "end": "(?<!\\\\)(?=\n)",
+                    "patterns": [
+                        {
+                            "include": "#line-continuation"
+                        }
+                    ]
+                }
+            ]
+        },
+        "string-char-literal": {
+            "patterns": [
+                {
+                    "comment": "STRING LITERAL",
+                    "name": "string.quoted.double.hlsl",
+                    "begin": "\"",
+                    "end": "(\"|(?<!\\\\)(?=\n))",
+                    "patterns": [
+                        {
+                            "include": "#character-escape"
+                        }
+                    ]
+                },
+                {
+                    "comment": "CHAR LITERAL",
+                    "name": "string.quoted.single.hlsl",
+                    "begin": "'",
+                    "end": "('|(?<!\\\\)(?=\n))",
+                    "patterns": [
+                        {
+                            "include": "#character-escape"
+                        }
+                    ]
+                }
+            ]
+        },
+        "line-continuation": {
+            "comment": "LINE CONTINUATION CHARACTER",
+            "name": "constant.character.escape.hlsl",
+            "match": "\\\\$"
+        },
+        "character-escape": {
+            "patterns": [
+                {
+                    "include": "#line-continuation"
+                },
+                {
+                    "comment": "HEX ESCAPE CHARACTER",
+                    "name": "constant.character.escape.hlsl",
+                    "match": "\\\\x[0-9a-fA-F][0-9a-fA-F]?"
+                },
+                {
+                    "comment": "OCTAL ESCAPE CHARACTER",
+                    "name": "constant.character.escape.hlsl",
+                    "match": "\\\\[0-7]([0-7][0-7]?)?"
+                },
+                {
+                    "comment": "ESCAPE CHARACTER",
+                    "name": "constant.character.escape.hlsl",
+                    "match": "\\\\."
+                }
+            ]
+        },
+        "language-constant": {
+            "patterns": [
+                {
+                    "comment": "BOOL AND NULL LITERAL",
+                    "name": "constant.language.hlsl",
+                    "match": "\\b(true|false|NULL)\\b"
+                },
+                {
+                    "comment": "REGISTER TYPE",
+                    "name": "constant.language.hlsl",
+                    "match": "(?<=\\b(register)(\\s|/\\*.*?\\*/)*\\((\\s|/\\*.*?\\*/)*)((b|t|c|s|u|r|x|v|cb|icb|o|oDepth|oMask|vPrim|vInstanceID|vicp|vocp|vForkInstanceID|vpc|vJoinInstanceID|vcp|vDomain|g|vThreadID|vThreadGroupID|vThreadIDInGroup|vThreadIDInGroupFlattened)\\d*)"
+                },
+                {
+                    "comment": "PACKAGEOFFSET TYPE",
+                    "name": "constant.language.hlsl",
+                    "match": "(?<=\\b(packageoffset)(\\s|/\\*.*?\\*/)*\\((\\s|/\\*.*?\\*/)*)c"
+                }
+            ]
+        },
+        "number-literal": {
+            "patterns": [
+                {
+                    "comment": "FLOATING POINT LITERAL",
+                    "name": "constant.numeric.hlsl",
+                    "match": "((\\d+?\\.\\d+|\\d+\\.)([eE][+-]?\\d+)?|\\d+[eE][+-]?\\d+)[hHfFlL]?"
+                },
+                {
+                    "comment": "FIXED POINT LITERAL",
+                    "name": "constant.numeric.hlsl",
+                    "match": "(0[xX](\\d|[a-fA-F])+|[1-9]\\d*|0[0-7]*)[uUlL]?"
+                }
+            ]
+        },
+        "modifier": {
+            "patterns": [
+                {
+                    "comment": "MODIFIER",
+                    "name": "storage.modifier.hlsl",
+                    "match": "\\b(centroid|column_major|const|export|extern|groupshared|in|inline|inout|line|lineadj|linear|nointerpolation|noperspective|out|packoffset|point|precise|register|row_major|sample|shared|snorm|static|triangle|triangleadj|uniform|unorm|unsigned|volatile|globallycoherent)\\b"
+                },
+                {
+                    "comment": "ATTRIBUTE",
+                    "name": "storage.modifier.hlsl",
+                    "match": "(?<=\\[(\\s|/\\*.*?\\*/)*)(domain|earlydepthstencil|instance|maxtessfactor|numthreads|outputcontrolpoints|outputtopology|partitioning|patchconstantfunc|fastopt|unroll|loop|allow_uav_condition|branch|flatten|call|maxvertexcount|ifAll|ifAny|isolate|maxexports|maxInstructionCount|maxtempreg|noExpressionOptimizations|predicate|predicateBlock|reduceTempRegUsage|removeUnusedInputs|sampreg|unused|xps|WaveSize|forcecase)\\b"
+                },
+                {
+                    "comment": "SEMANTIC",
+                    "name": "storage.modifier.hlsl",
+                    "match": "(?<=:(\\s|/\\*.*?\\*/)*)((BINORMAL|BLENDINDICES|BLENDWEIGHT|COLOR|NORMAL|POSITION|POSITIONT|PSIZE|TANGENT|TEXCOORD|TESSFACTOR|DEPTH)\\d*|FOG|VFACE|VPOS)\\b"
+                },
+                {
+                    "comment": "NUMBERED SYSTEM VALUE SEMANTIC",
+                    "name": "storage.modifier.hlsl",
+                    "match": "(?i)(?<=:(\\s|/\\*.*?\\*/)*)(SV_Target[0-7]?|(SV_ClipDistance|SV_CullDistance)\\d*)\\b"
+                },
+                {
+                    "comment": "NON-NUMBERED SYSTEM VALUE SEMANTIC",
+                    "name": "storage.modifier.hlsl",
+                    "match": "(?i)(?<=:(\\s|/\\*.*?\\*/)*)(SV_Coverage|SV_Depth|SV_DepthGreaterEqual|SV_DepthLessEqual|SV_DispatchThreadID|SV_DomainLocation|SV_GroupID|SV_GroupIndex|SV_GroupThreadID|SV_GSInstanceID|SV_InnerCoverage|SV_StencilRef|SV_InsideTessFactor|SV_InstanceID|SV_IsFrontFace|SV_OutputControlPointID|SV_Position|SV_PrimitiveID|SV_RenderTargetArrayIndex|SV_SampleIndex|SV_TessFactor|SV_VertexID|SV_ViewportArrayIndex|SV_ShadingRate|SV_ViewID|SV_Barycentrics)\\b"
+                }
+            ]
+        },
+        "preprocessor-directive": {
+            "comment": "PREPROCESSOR",
+            "name": "meta.preprocessor.hlsl",
+            "begin": "(?=#)",
+            "end": "(?<!\\\\)(?=\n)",
+            "patterns": [
+                {
+                    "comment": "HLSL PREPROCESSOR DIRECTIVE",
+                    "name": "keyword.control.hlsl",
+                    "match": "#((\\s|/\\*.*?\\*/)*)(define|elif|else|endif|error|if|ifdef|ifndef|include|line|pragma|undef)\\b",
+                    "captures": {
+                        "1": { "name": "comment.block.hlsl" }
+                    }
+                },
+                {
+                    "comment": "DAGORSH PREPROCESSOR DIRECTIVE",
+                    "name": "keyword.control.hlsl",
+                    "match": "##((\\s|/\\*.*?\\*/)*)(elif|else|endif|if)\\b",
+                    "captures": {
+                        "1": { "name": "comment.block.hlsl" }
+                    }
+                },
+                {
+                    "comment": "INCLUDE DIRECTIVE",
+                    "begin": "(?<=include)",
+                    "end": "(?<!\\\\)(?=\n)",
+                    "patterns": [
+                        { "include": "#comment" },
+                        { "include": "#string-char-literal" },
+                        {
+                            "comment": "ANGLE BRACKET INCLUDE PATH",
+                            "name": "string.other.hlsl",
+                            "begin": "<",
+                            "end": ">|(?<!\\\\)(?=\n)",
+                            "patterns": [{ "include": "#character-escape" }]
+                        }
+                    ]
+                },
+                {
+                    "comment": "ERROR DIRECTIVE",
+                    "name": "string.other.hlsl",
+                    "begin": "(?<=error)",
+                    "end": "(?<!\\\\)(?=\n)",
+                    "patterns": [{ "include": "#character-escape" }]
+                },
+                {
+                    "comment": "PRAGMA DIRECTIVE",
+                    "match": "(?<=pragma(\\s|/\\*.*?\\*/)+)((def|message|pack_matrix|warning)|([a-zA-Z_]\\w*))",
+                    "captures": {
+                        "3": { "name": "keyword.control.hlsl" },
+                        "4": { "name": "meta.preprocessor.hlsl" }
+                    }
+                },
+                {
+                    "comment": "DEFINE DIRECTIVE",
+                    "name": "variable.hlsl",
+                    "match": "(?<=define\\s+)[a-zA-Z_]\\w*\\b(?!\\()"
+                },
+                {
+                    "comment": "PREPROCESSOR ONLY OPERATOR",
+                    "name": "keyword.operator.hlsl",
+                    "match": "##|#@|defined"
+                },
+                {
+                    "include": "$self"
+                }
+            ]
+        },
+        "template": {
+            "patterns": [
+                {
+                    "comment": "TEMPLATE",
+                    "name": "storage.type.hlsl",
+                    "match": "\\b(template)\\b"
+                },
+                {
+                    "comment": "TEMPLATE ARGUMENT",
+                    "match": "(?<=<)((\\w+|\\s|[+\\-*/%\\[\\]~^(),.])+)(?=>)",
+                    "captures": {
+                        "1": {
+                            "patterns": [
+                                { "include": "#language-constant" },
+                                { "include": "#function" },
+                                { "include": "#built-in-type" },
+                                {
+                                    "name": "entity.name.type.hlsl",
+                                    "match": "\\b([a-zA-Z_]\\w*)\\b"
+                                },
+                                { "include": "$self" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "keyword-operator": {
+            "patterns": [
+                {
+                    "comment": "CONTROL KEYWORD",
+                    "name": "keyword.control.hlsl",
+                    "match": "\\b(break|continue|discard|return|for|if|else|switch|case|default|do|while|compile|compile_fragment)\\b"
+                },
+                {
+                    "comment": "TYPEDEF",
+                    "match": "\\b(typedef)(\\b([^;=]+)\\b([a-zA-Z_]\\w*))?",
+                    "captures": {
+                        "1": { "name": "keyword.other.hlsl" },
+                        "3": { "patterns": [{ "include": "$self" }] },
+                        "4": { "name": "entity.name.type.hlsl" }
+                    }
+                },
+                {
+                    "comment": "OTHER KEYWORD",
+                    "name": "keyword.other.hlsl",
+                    "match": "\\b(asm|asm_fragment|fxgroup|pixelfragment|vertexfragment|stateblock|stateblock_state|technique|technique10|technique11|pass)\\b"
+                },
+                {
+                    "comment": "OPERATOR",
+                    "name": "keyword.operator.hlsl",
+                    "match": "[+\\-*/%\\[\\]~<>&|^?:(),.!=]"
+                }
+            ]
+        },
+        "type-declaration": {
+            "comment": "TYPE DECLARATION",
+            "match": "\\b((enum)((\\s|/\\*.*?\\*/)+)(class)|(struct|enum|class|interface|namespace|typename))\\b(((\\s|/\\*.*?\\*/)+)([a-zA-Z_]\\w*))?",
+            "captures": {
+                "2": { "name": "storage.type.hlsl" },
+                "3": { "name": "comment.block.hlsl" },
+                "5": { "name": "storage.type.hlsl" },
+                "6": { "name": "storage.type.hlsl" },
+                "8": { "name": "comment.block.hlsl" },
+                "10": { "name": "entity.name.type.hlsl" }
+            }
+        },
+        "function": {
+            "patterns": [
+                {
+                    "comment": "VOID",
+                    "name": "storage.type.hlsl",
+                    "match": "\\b(void)\\b"
+                },
+                {
+                    "comment": "FUNCTION",
+                    "name": "entity.name.function.hlsl",
+                    "match": "([a-zA-Z_]\\w*|operator([+\\-*/%\\[\\]~<>&|^?:(),.!=]|\\s)*)(?=(\\s|/\\*.*?\\*/)*(<[^=;]*>)?(\\s|/\\*.*?\\*/)*\\()"
+                }
+            ]
+        },
+        "built-in-type": {
+            "patterns": [
+                {
+                    "comment": "BUFFER TYPE",
+                    "name": "support.class.hlsl",
+                    "match": "\\b(AppendStructuredBuffer|Buffer|ByteAddressBuffer|ConsumeStructuredBuffer|RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|StructuredBuffer|tbuffer|cbuffer|ConstantBuffer|RasterizerOrderedBuffer|RasterizerOrderedByteAddressBuffer|RasterizerOrderedStructuredBuffer)\\b"
+                },
+                {
+                    "comment": "TEXTURE TYPE",
+                    "name": "support.class.hlsl",
+                    "match": "\\b((sampler|texture)(1D|2D|3D|CUBE)?|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D|Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray|FeedbackTexture2D|FeedbackTexture2DArray|RasterizerOrderedTexture1D|RasterizerOrderedTexture1DArray|RasterizerOrderedTexture2D|RasterizerOrderedTexture2DArray|RasterizerOrderedTexture3D)\\b"
+                },
+                {
+                    "comment": "OTHER NON-PRIMITIVE TYPE",
+                    "name": "support.class.hlsl",
+                    "match": "\\b(BlendState|DepthStencilState|InputPatch|LineStream|OutputPatch|PointStream|RasterizerState|SamplerState|SamplerComparisonState|TriangleStream|sampler_state|ComputeShader|DomainShader|GeometryShader|HullShader|PixelShader|VertexShader|RenderTargetView|DepthStencilView|Technique|RayQuery)\\b"
+                },
+                {
+                    "comment": "DAGOR NON-PRIMITIVE TYPE",
+                    "name": "support.class.hlsl",
+                    "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|shd|buf|cbuf|uav)\\b"
+                },
+                {
+                    "comment": "VECTOR, MATRIX AND STRING TYPE",
+                    "name": "storage.type.hlsl",
+                    "match": "\\b(vector|matrix|string)\\b"
+                },
+                {
+                    "comment": "OTHER PRIMITIVE TYPE",
+                    "name": "storage.type.hlsl",
+                    "match": "\\b(bool|int|uint|dword|half|float|double|min16float|min10float|min16int|min12int|min16uint|uint64_t|int64_t|float16_t|uint16_t|int16_t|float32_t|float64_t|int32_t|uint32_t|uint8_t4_packed|int8_t4_packed)([1-4](x[1-4])?)?\\b"
+                },
+                {
+                    "comment": "DAGOR PRIMITIVE TYPE",
+                    "name": "storage.type.dagorsh",
+                    "match": "@((f|i)[1-4]|f44)\\b"
+                }
+            ]
+        },
+        "user-type": {
+            "comment": "USER TYPE",
+            "name": "entity.name.type.hlsl",
+            "match": "[a-zA-Z_]\\w*(?=((\\s|/\\*.*?\\*/)+[a-zA-Z_]\\w*))"
+        },
+        "variable": {
+            "comment": "VARIABLE",
+            "name": "variable.hlsl",
+            "match": "[a-zA-Z_]\\w*"
+        },
+        "semicolon": {
+            "comment": "SEMICOLON",
+            "name": "punctuation.hlsl",
+            "match": ";"
+        },
+        "test": {
+            "comment": "ONLY FOR DEBUGGING THE GRAMMAR",
+            "name": "invalid.illegal.hlsl",
+            "match": "."
+        }
+    }
+}

--- a/grammar/hlsl.tmLanguage.json
+++ b/grammar/hlsl.tmLanguage.json
@@ -341,7 +341,7 @@
                 },
                 {
                     "comment": "DAGOR NON-PRIMITIVE TYPE",
-                    "name": "support.class.hlsl",
+                    "name": "support.class.dagorsh",
                     "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|shd|buf|cbuf|uav)\\b"
                 },
                 {

--- a/grammar/hlsl.tmLanguage.json
+++ b/grammar/hlsl.tmLanguage.json
@@ -1,6 +1,7 @@
 {
     "scopeName": "source.hlsl",
     "name": "HLSL",
+    "fileTypes": ["hlsl"],
     "patterns": [
         { "include": "#block" },
         { "include": "#comment" },
@@ -326,22 +327,22 @@
             "patterns": [
                 {
                     "comment": "BUFFER TYPE",
-                    "name": "support.class.hlsl",
+                    "name": "storage.type.hlsl",
                     "match": "\\b(AppendStructuredBuffer|Buffer|ByteAddressBuffer|ConsumeStructuredBuffer|RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|StructuredBuffer|tbuffer|cbuffer|ConstantBuffer|RasterizerOrderedBuffer|RasterizerOrderedByteAddressBuffer|RasterizerOrderedStructuredBuffer)\\b"
                 },
                 {
                     "comment": "TEXTURE TYPE",
-                    "name": "support.class.hlsl",
+                    "name": "storage.type.hlsl",
                     "match": "\\b((sampler|texture)(1D|2D|3D|CUBE)?|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D|Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray|FeedbackTexture2D|FeedbackTexture2DArray|RasterizerOrderedTexture1D|RasterizerOrderedTexture1DArray|RasterizerOrderedTexture2D|RasterizerOrderedTexture2DArray|RasterizerOrderedTexture3D)\\b"
                 },
                 {
                     "comment": "OTHER NON-PRIMITIVE TYPE",
-                    "name": "support.class.hlsl",
+                    "name": "storage.type.hlsl",
                     "match": "\\b(BlendState|DepthStencilState|InputPatch|LineStream|OutputPatch|PointStream|RasterizerState|SamplerState|SamplerComparisonState|TriangleStream|sampler_state|ComputeShader|DomainShader|GeometryShader|HullShader|PixelShader|VertexShader|RenderTargetView|DepthStencilView|Technique|RayQuery)\\b"
                 },
                 {
                     "comment": "DAGOR NON-PRIMITIVE TYPE",
-                    "name": "support.class.dagorsh",
+                    "name": "storage.type.dagorsh",
                     "match": "@((tex|smp)(2d|3d|Array|Cube|CubeArray)?|shd|buf|cbuf|uav)\\b"
                 },
                 {

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,8 +37,8 @@ export abstract class Server {
     }
 
     protected addFeatures(): void {
-        this.addMockedCodeCompletion();
-        this.addMockedDiagnostics();
+        // this.addMockedCodeCompletion();
+        // this.addMockedDiagnostics();
     }
 
     private addMockedCodeCompletion(): void {


### PR DESCRIPTION
- Adding a TextMate grammar for both the Dagor Shader Language and HLSL
- Other small changes, like updating the readme

Grammar improvements:
- Coloring built-in and custom types
- Coloring custom functions
- Coloring attributes
- Adding new types like `RayQuery`, or `int8_t4_packed`
- More accurate coloring in typedefs, string, etc.
- Handling templates

The grammars have limitations, because TextMate works in a line-by-line fashion, and regular expressions can't express everything. However, in practice, it works most of the time, and with semantic highlight, errors can be fixed from code.

VS Code before:
<img width="322" alt="before" src="https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/assets/132660383/ecf052fd-431e-4696-9880-8586768c2b1a">
VS Code after:
<img width="322" alt="after" src="https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/assets/132660383/0b95f247-4425-431e-818f-6216b006d934">
Visual Studio:
![VS](https://github.com/Gaijin-Games-KFT/Dagor-Shader-Language-Server/assets/132660383/b8a27879-9b44-4932-9690-f74905598b03)
